### PR TITLE
rspec: Remove Puppet::Util::Storage mock

### DIFF
--- a/spec/lib/augeas_spec.rb
+++ b/spec/lib/augeas_spec.rb
@@ -13,8 +13,4 @@ RSpec.configure do |config|
   config.extend AugeasSpec::Fixtures
   config.include AugeasSpec::Augparse
   config.include AugeasSpec::Fixtures
-
-  config.before do
-    allow(Puppet::Util::Storage).to receive(:store)
-  end
 end


### PR DESCRIPTION
In attempting to upgrade <https://github.com/bodgit/puppet-postfix>'s dependency on this
module, I received the following error:

```
  Failure/Error: allow(Puppet::Util::Storage).to receive(:store)
    The use of doubles or partial doubles from rspec-mocks outside
    of the per-test lifecycle is not supported.
```

This appears to be the result of the change in
https://github.com/voxpupuli/puppet-augeasproviders_core/commit/637108ebcdab86b2de29ff51b41dfc6db39ab4d9 to use a mock rather than a stub. However, it is not clear to me why Puppet::Util::Storage needs to
be mocked, as all tests still pass in this module and puppet-postfix
without it, so remove.