### PR TITLE
Use expect() instead of .should

### DIFF
--- a/spec/lib/augeas_spec/fixtures.rb
+++ b/spec/lib/augeas_spec/fixtures.rb
@@ -31,10 +31,10 @@ module AugeasSpec::Fixtures
     # Check for warning+ log messages
     loglevels = Puppet::Util::Log.levels[3, 999]
     firstlogs = @logs.dup
-    @logs.select { |log| loglevels.include?(log.level) && log.message !~ %r{'modulepath' as a setting} }.should be_empty
+    expect(@logs.select { |log| loglevels.include?(log.level) && log.message !~ %r{'modulepath' as a setting} }).to eq([])
 
     # Check for transaction success after, as it's less informative
-    txn.any_failed?.should_not eq(true)
+    expect(txn.any_failed?).to be_nil
 
     # Run the exact same resources, but this time ensure there were absolutely
     # no changes (as seen by logs) to indicate if it was idempotent or not
@@ -43,8 +43,8 @@ module AugeasSpec::Fixtures
     loglevels = Puppet::Util::Log.levels[2, 999]
     againlogs = @logs.select { |log| loglevels.include? log.level }
 
-    againlogs.should eq([]), "expected no change on second run (idempotence check),\n     got: #{againlogs.inspect}"
-    txn_idempotent.any_failed?.should_not eq(true), 'expected no change on second run (idempotence check), got a resource failure'
+    expect(againlogs).to eq([]), 'expected no change on second run (idempotence check)'
+    expect(txn_idempotent.any_failed?).to be_nil, 'expected no change on second run (idempotence check), got a resource failure'
 
     @logs = firstlogs
     txn


### PR DESCRIPTION
This removes deprecation warnings from the process output.

It also uses eq([]) instead of be_empty since it's easier to debug: the diff is more useful.