### PR TITLE
Workaround libaugeas save/load issue

### DIFF
--- a/lib/puppet/provider/augeasprovider/default.rb
+++ b/lib/puppet/provider/augeasprovider/default.rb
@@ -162,6 +162,10 @@ Puppet::Type.type(:augeasprovider).provide(:default) do
     raise Augeas::Error, 'Failed to save Augeas tree to file. See debug logs for details.'
   ensure
     aug.load! if reload
+    # https://github.com/hercules-team/augeas/commit/eb04250a05671b2d001444b72b8778328d209d75 introduced a bug in libaugeas.so.0.25.0
+    # bundled with puppet7.
+    # A temporary fix is to invoke load! twice.
+    aug.load! if reload && Puppet::Util::Package.versioncmp(aug_version, '1.13.0') >= 0
   end
 
   # Define a method with a block passed to #augopen

--- a/spec/unit/puppet/provider/augeasprovider/default_spec.rb
+++ b/spec/unit/puppet/provider/augeasprovider/default_spec.rb
@@ -467,6 +467,26 @@ describe provider_class do
           -> { provider.augsave!(aug) }.should raise_error Augeas::Error, %r{Failed to save Augeas tree}
         end
       end
+
+      describe 'with reload' do
+        it 'is expected to call #load! once with augeas < 1.13.0' do
+          provider.augopen(resource) do |aug|
+            allow(provider).to receive(:aug_version).twice.and_return '1.12.0' # rubocop:disable RSpec/SubjectStub
+            expect(aug).to receive(:load!).once
+            aug.set("/files#{thetarget}/dummy")
+            provider.augsave!(aug, true)
+          end
+        end
+
+        it 'is expected to call #load! twice with augeas >= 1.13.0' do
+          provider.augopen(resource) do |aug|
+            allow(provider).to receive(:aug_version).twice.and_return '1.13.0' # rubocop:disable RSpec/SubjectStub
+            expect(aug).to receive(:load!).twice
+            aug.set("/files#{thetarget}/dummy")
+            provider.augsave!(aug, true)
+          end
+        end
+      end
     end
 
     describe '#path_label' do


### PR DESCRIPTION
#### Pull Request (PR) description
https://github.com/hercules-team/augeas/pull/691 introduced a bug in libaugeas bundled with puppet 7.
The bug manifests it self in this modules augsave! method when invoked with reload=true.
A workaround is to invoke aug.load! twice after an aug.save! 
See https://github.com/voxpupuli/puppet-augeasproviders_sysctl/pull/65