### PR TITLE
Drop unneeded stdlib dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -54,7 +54,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 7.0.0 < 8.0.0"
+      "version_requirement": ">= 7.0.0 < 9.0.0"
     }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -7,12 +7,7 @@
   "source": "https://github.com/voxpupuli/puppet-augeasproviders_core",
   "project_page": "https://github.com/voxpupuli/puppet-augeasproviders_core",
   "issues_url": "https://github.com/voxpupuli/puppet-augeasproviders_core/issues",
-  "dependencies": [
-    {
-      "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 3.2.0 < 9.0.0"
-    }
-  ],
+  "dependencies": [],
   "operatingsystem_support": [
     {
       "operatingsystem": "Debian",


### PR DESCRIPTION
also contains https://github.com/voxpupuli/puppet-augeasproviders_core/pull/53