### PR TITLE
Remove old arguments to augopen_internal

### DIFF
--- a/lib/puppet/provider/augeasprovider/default.rb
+++ b/lib/puppet/provider/augeasprovider/default.rb
@@ -95,7 +95,7 @@ Puppet::Type.type(:augeasprovider).provide(:default) do
   # @raise [Puppet::Error] if Augeas did not load the file
   # @api public
   def self.augopen(resource = nil, yield_resource = false, *yield_params, &block)
-    augopen_internal(resource, false, yield_resource, *yield_params, &block)
+    augopen_internal(resource, yield_resource, *yield_params, &block)
   end
 
   # Opens Augeas and returns a handle to use.  It loads only the file
@@ -121,7 +121,7 @@ Puppet::Type.type(:augeasprovider).provide(:default) do
   # @raise [Puppet::Error] if Augeas did not load the file
   # @api public
   def self.augopen!(resource = nil, yield_resource = false, *yield_params, &block)
-    augopen_internal(resource, true, yield_resource, *yield_params, &block)
+    augopen_internal(resource, yield_resource, *yield_params, &block)
   end
 
   # Saves all changes made in the current Augeas handle and checks for any


### PR DESCRIPTION
In the [refactor](https://github.com/voxpupuli/puppet-augeasproviders_core/commit/31abd4b6af444a7dc35a40ddfa01a8ca1e2b7020) the autosave argument was removed, but it wasn't removed
when it was called.

Fixes #57