### PR TITLE
fix: setup logs in rspec fixtures lib

### DIFF
--- a/spec/lib/augeas_spec/fixtures.rb
+++ b/spec/lib/augeas_spec/fixtures.rb
@@ -28,6 +28,10 @@ module AugeasSpec::Fixtures
   def apply!(*resources)
     txn = apply(*resources)
 
+    if @logs.nil?
+      @logs = []
+      Puppet::Util::Log.newdestination(Puppet::Test::LogCollector.new(@logs))
+    end
     # Check for warning+ log messages
     loglevels = Puppet::Util::Log.levels[3, 999]
     firstlogs = @logs.dup


### PR DESCRIPTION
this was previously done in PSH
https://github.com/puppetlabs/puppetlabs_spec_helper/blob/main/lib/puppetlabs_spec_helper/puppet_spec_helper.rb#L77
