### PR TITLE
fix: setup logs in rspec fixtures lib

### DIFF
--- a/spec/lib/augeas_spec/fixtures.rb
+++ b/spec/lib/augeas_spec/fixtures.rb
@@ -16,6 +16,11 @@ module AugeasSpec::Fixtures
 
   # Runs a particular resource via a catalog
   def apply(*resources)
+    if @logs.nil?
+      @logs = []
+      Puppet::Util::Log.newdestination(Puppet::Test::LogCollector.new(@logs))
+    end
+
     catalog = Puppet::Resource::Catalog.new
     catalog.host_config = false
     resources.each do |resource|


### PR DESCRIPTION
this was previously done in PSH
https://github.com/puppetlabs/puppetlabs_spec_helper/blob/main/lib/puppetlabs_spec_helper/puppet_spec_helper.rb#L77

